### PR TITLE
Update canary_buffer.h

### DIFF
--- a/msc/canary_buffer.h
+++ b/msc/canary_buffer.h
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <memory>
+#include <limits>
 
 #include "msc/utils_publishable.h"
 


### PR DESCRIPTION
missing header - build fails on ubuntu 22.04